### PR TITLE
Update fail hook to remove the selector

### DIFF
--- a/includes/class-wc-monei-redirect-hooks.php
+++ b/includes/class-wc-monei-redirect-hooks.php
@@ -38,6 +38,7 @@ class WC_Monei_Redirect_Hooks {
 		if ( $status === 'FAILED' ) {
 			wc_add_notice(__('The payment failed. Please try again', 'monei'), 'error');
 		}
+		add_filter('woocommerce_payment_gateway_get_new_payment_method_option_html', '__return_empty_string');
 	}
 
 	/**


### PR DESCRIPTION
WooCommerce adds a selector to add a new payment method, but on the retry page we do not want to see it