### PR TITLE
Fix/move settings into payments

### DIFF
--- a/assets/css/monei-admin.css
+++ b/assets/css/monei-admin.css
@@ -15,3 +15,11 @@
 .monei-settings-header-welcome p {
     font-size: 16px;
 }
+/* Hide the Monei tab in the main row of WooCommerce settings */
+.wc-settings-sub-nav a[href*="tab=monei_settings"] {
+    display: none !important;
+}
+/* Also hide it in the "horizontal" tabs if WooCommerce uses them */
+.nav-tab-wrapper a.nav-tab[href*="tab=monei_settings"] {
+    display: none !important;
+}

--- a/src/Settings/MoneiSettings.php
+++ b/src/Settings/MoneiSettings.php
@@ -77,6 +77,7 @@ class MoneiSettings extends \WC_Settings_Page {
 			'welcomeString'   => __( 'Welcome to MONEI! Enhance your payment processing experience with our seamless integration', 'monei' ),
 			'dashboardString' => __( 'Go to Dashboard', 'monei' ),
 			'supportString'   => __( 'Support', 'monei' ),
+			'reviewString'    => __( 'Leave a review', 'monei' ),
 		);
 
 		$templateManager = $this->container->get( 'Monei\Templates\TemplateManager' );

--- a/src/Templates/NoticeAdminNewInstall.php
+++ b/src/Templates/NoticeAdminNewInstall.php
@@ -14,7 +14,7 @@ class NoticeAdminNewInstall implements TemplateInterface {
 					href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'monei-hide-new-version', 'hide-new-version-monei' ), 'monei_hide_new_version_nonce', '_monei_hide_new_version_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'monei' ); ?></a>
 				<p>
 				<h3>
-					<?php esc_html_e( 'Thank you for install MONEI for WooCommerce. Version: ', 'monei' ) . ' ' . esc_html( MONEI_VERSION ); ?>
+					<?php echo esc_html__( 'Thank you for install MONEI for WooCommerce. Version: ', 'monei' ). ' ' . esc_html(MONEI_VERSION) ?>
 				</h3>
 				</p>
 				<p>
@@ -25,10 +25,6 @@ class NoticeAdminNewInstall implements TemplateInterface {
 						target="_blank"><?php esc_html_e( 'Signup', 'monei' ); ?></a>
 					<a href="<?php echo esc_url( MONEI_WEB ); ?>" class="button-primary"
 						target="_blank"><?php esc_html_e( 'MONEI website', 'monei' ); ?></a>
-					<a href="<?php echo esc_url( MONEI_REVIEW ); ?>" class="button-primary"
-						target="_blank"><?php esc_html_e( 'Leave a review', 'monei' ); ?></a>
-					<a href="<?php echo esc_url( MONEI_SUPPORT ); ?>" class="button-primary"
-						target="_blank"><?php esc_html_e( 'Support', 'monei' ); ?></a>
 				</p>
 			</div>
 		</div>

--- a/src/Templates/SettingsHeader.php
+++ b/src/Templates/SettingsHeader.php
@@ -10,6 +10,7 @@ class SettingsHeader implements TemplateInterface {
 		$welcomeString   = $data['welcomeString'] ?? '';
 		$dashboardString = $data['dashboardString'] ?? '';
 		$supportString   = $data['supportString'] ?? '';
+		$reviewString    = $data['reviewString'] ?? '';
 		?>
 
 		<div class="monei-settings-header-logo">
@@ -19,8 +20,9 @@ class SettingsHeader implements TemplateInterface {
 			<p><?php echo esc_html( $welcomeString ); ?></p>
 		</div>
 		<div class="monei-settings-header-buttons">
-			<a href="https://dashboard.monei.com" class="button button-primary" target="_blank"><?php echo esc_html( $dashboardString ); ?></a>
-			<a href="https://support.monei.com/" class="button" target="_blank"><?php echo esc_html( $supportString ); ?></a>
+			<a href="<?php echo esc_url( MONEI_SIGNUP ); ?>" class="button button-primary" target="_blank"><?php echo esc_html( $dashboardString ); ?></a>
+			<a href="<?php echo esc_url( MONEI_SUPPORT ); ?>" class="button" target="_blank"><?php echo esc_html( $supportString ); ?></a>
+			<a href="<?php echo esc_url( MONEI_REVIEW ); ?>" class="button" target="_blank"><?php echo esc_html( $reviewString ); ?></a>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
This PR removes the `support` and `add a review` links in the welcome banner to add them to the settings header. The settings header tab is hidden and the way to arrive to it it's via the link on each payment method, as requested