### PR TITLE
Fix/package creation action

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -14,3 +14,4 @@ docker_tag
 package.json
 package-lock.json
 webpack.config.js
+phpcs.xml

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -13,16 +13,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Cache Composer dependencies
-        uses: actions/cache@v3
-        with:
-          path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
-
       - name: Install Composer dependencies
-        uses: php-actions/composer@v6
+        uses: ramsey/composer-install@v3
         with:
-            args: --no-dev --optimize-autoloader
+            composer-options: --no-dev --optimize-autoloader
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -34,9 +28,6 @@ jobs:
 
       - name: Build assets with wp-scripts
         run: npm run build
-
-      - name: Remove dev dependencies
-        run: composer install --no-dev --optimize-autoloader
 
       - name: Exclude files listed in .distignore
         run: |

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -19,7 +19,11 @@ jobs:
           path: /tmp/composer-cache
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
 
-      - uses: php-actions/composer@v6
+      - name: Install Composer dependencies
+        uses: php-actions/composer@v6
+        with:
+            args: --no-dev --optimize-autoloader
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -30,6 +34,9 @@ jobs:
 
       - name: Build assets with wp-scripts
         run: npm run build
+
+      - name: Remove dev dependencies
+        run: composer install --no-dev --optimize-autoloader
 
       - name: Exclude files listed in .distignore
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Cache Composer dependencies
-      uses: actions/cache@v3
+    - name: Install Composer dependencies
+      uses: ramsey/composer-install@v3
       with:
-        path: /tmp/composer-cache
-        key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
-
-    - uses: php-actions/composer@v6
+        composer-options: --no-dev --optimize-autoloader
 
     - name: Setup Node.js
       uses: actions/setup-node@v3


### PR DESCRIPTION
Optimize package creation workflow

- Use ramsey/composer-install@v3 action
- Add --no-dev --optimize-autoloader flags to Composer install
- Exclude development dependencies from the final package
- Streamline the build process for WordPress.org deployment