### PR TITLE
Release/6.3.3

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monei-woocommerce",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "main": "index.js",
   "repository": "git@github.com:MONEI/MONEI-WooCommerce.git",
   "author": "MONEI <support@monei.com>",

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** MONEI Payments for WooCommerce ***
 
+2025-05-05 - version 6.3.3
+* Fix - Error copying old keys that hides the gateway
+
 2025-05-05 - version 6.3.2
 * Fix - Error in checkout when no subscription plugin present
 * Fix - Showing only available payment methods when subscription product in cart

--- a/class-woocommerce-gateway-monei.php
+++ b/class-woocommerce-gateway-monei.php
@@ -5,7 +5,7 @@
  * @author   MONEI
  * @category Core
  * @package  Woocommerce_Gateway_Monei
- * @version  6.3.2
+ * @version  6.3.3
  */
 
 use Monei\Core\ContainerProvider;
@@ -25,7 +25,7 @@ if ( ! class_exists( 'Woocommerce_Gateway_Monei' ) ) :
 		 *
 		 * @var string
 		 */
-		public $version = '6.3.2';
+		public $version = '6.3.3';
 
 		/**
 		 * The single instance of the class.

--- a/includes/admin/monei-cc-settings.php
+++ b/includes/admin/monei-cc-settings.php
@@ -24,7 +24,7 @@ return apply_filters(
 		'top_link'         => array(
 			'title'       => '',
 			'type'        => 'title',
-			'description' => '<a href="' . $settings_link . '" class="button">' . __( 'Go to MONEI Api key Settings', 'monei' ) . '</a>',
+			'description' => '<a href="' . $settings_link . '" class="button">' . __( 'Go to MONEI API key Settings', 'monei' ) . '</a>',
 			'id'          => 'cc_monei_top_link',
 		),
 		'enabled'          => array(

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Tags: woocommerce, credit card, payment gateway, payments, ecommerce
 Contributors: monei, furi3r
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 6.3.2
+Stable tag: 6.3.3
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -102,6 +102,9 @@ By using this plugin you agree with MONEI [Terms of Service](https://monei.com/l
 2. Google Pay, Bizum, PayPal, credit Card
 
 == Changelog ==
+
+2025-05-05 - version 6.3.3
+* Fix - Error copying old keys that hides the gateway
 
 2025-05-05 - version 6.3.2
 * Fix - Error in checkout when no subscription plugin present

--- a/src/Services/ApiKeyService.php
+++ b/src/Services/ApiKeyService.php
@@ -65,6 +65,12 @@ class ApiKeyService {
 		add_filter(
 			'option_woocommerce_monei_settings',
 			function ( $default_params ) {
+                $newCentralTestApiKey    = get_option( 'monei_test_apikey', '' );
+                $newCentralLiveApiKey   = get_option( 'monei_live_apikey', '' );
+                //we already saved the new keys, so we don't need to do anything more here.'
+                if(! empty( $newCentralTestApiKey ) ||! empty( $newCentralLiveApiKey ) ) {
+                    return $default_params;
+                }
 				$centralApiKey    = get_option( 'monei_apikey', '' );
 				$centralAccountId = get_option( 'monei_accountid', '' );
 				$ccApiKey         = $default_params['apikey'] ?? '';
@@ -80,14 +86,10 @@ class ApiKeyService {
 					update_option( 'monei_test_apikey', $keyToUse );
 					update_option( 'monei_apikey_mode', 'test' );
                     update_option( 'monei_test_accountid', $accountId );
-				    delete_option( 'monei_apikey' );
-                    delete_option( 'monei_accountid' );
 				} else if(strpos( $keyToUse, 'pk_live_' ) === 0) {
 					update_option( 'monei_live_apikey', $keyToUse );
 					update_option( 'monei_apikey_mode', 'live' );
                     update_option( 'monei_live_accountid', $accountId );
-				    delete_option( 'monei_apikey' );
-                    delete_option( 'monei_accountid' );
                 }
 
 				return $default_params;

--- a/src/Templates/NoticeGatewayNotAvailable.php
+++ b/src/Templates/NoticeGatewayNotAvailable.php
@@ -5,9 +5,21 @@ namespace Monei\Templates;
 class NoticeGatewayNotAvailable implements TemplateInterface {
 
 	public function render( $data ): void {
-		?>
+        $settings_link = esc_url(
+            admin_url(
+                add_query_arg(
+                    array(
+                        'page' => 'wc-settings',
+                        'tab'  => 'monei_settings',
+                    ),
+                    'admin.php'
+                )
+            )
+        );
+        ?>
+        <a class="button" href="<?php echo esc_url( $settings_link );?>"><?php esc_html_e(  'Go to MONEI API key Settings', 'monei' )?></a>
 
-		<div class="inline error">
+        <div class="inline error">
 			<p>
 				<strong><?php esc_html_e( 'Gateway Disabled', 'monei' ); ?></strong>: <?php esc_html_e( 'MONEI only support EUROS, USD & GBP currencies.', 'monei' ); ?>
 			</p>

--- a/src/Templates/NoticeGatewayNotAvailableApi.php
+++ b/src/Templates/NoticeGatewayNotAvailableApi.php
@@ -5,20 +5,21 @@ namespace Monei\Templates;
 class NoticeGatewayNotAvailableApi implements TemplateInterface {
 
 	public function render( $data ): void {
-		$settings_link = esc_url(
-			admin_url(
-				add_query_arg(
-					array(
-						'page' => 'wc-settings',
-						'tab'  => 'monei_settings',
-					),
-					'admin.php'
-				)
-			)
-		);
-		?>
+        $settings_link = esc_url(
+            admin_url(
+                add_query_arg(
+                    array(
+                        'page' => 'wc-settings',
+                        'tab'  => 'monei_settings',
+                    ),
+                    'admin.php'
+                )
+            )
+        );
+        ?>
+        <a class="button" href="<?php echo esc_url( $settings_link );?>"><?php esc_html_e(  'Go to MONEI API key Settings', 'monei' )?></a>
 
-		<div class="inline error">
+        <div class="inline error">
 			<p>
 				<strong><?php esc_html_e( 'Gateway Disabled', 'monei' ); ?></strong>: <?php esc_html_e( 'MONEI API key or Account ID is missing.', 'monei' ); ?>
 				<a href="<?php echo esc_url( $settings_link ); ?>"><?php esc_html_e( 'Go to MONEI API Key Settings', 'monei' ); ?></a>

--- a/src/Templates/NoticeGatewayNotEnabledMonei.php
+++ b/src/Templates/NoticeGatewayNotEnabledMonei.php
@@ -5,13 +5,25 @@ namespace Monei\Templates;
 class NoticeGatewayNotEnabledMonei implements TemplateInterface {
 
 	public function render( $data ): void {
-		?>
+        $settings_link = esc_url(
+            admin_url(
+                add_query_arg(
+                    array(
+                        'page' => 'wc-settings',
+                        'tab'  => 'monei_settings',
+                    ),
+                    'admin.php'
+                )
+            )
+        );
+        ?>
+        <a class="button" href="<?php echo esc_url( $settings_link );?>"><?php esc_html_e(  'Go to MONEI API key Settings', 'monei' )?></a>
 
 		<div class="inline error">
 			<p>
-				<strong><?php esc_html_e( 'Gateway Disabled', 'monei' ); ?></strong>: <?php esc_html_e( 'The selected payment method is not active in the MONEI dashboard.', 'monei' ); ?>
+				<strong><?php esc_html_e( 'Gateway Disabled', 'monei' ); ?></strong>: <?php esc_html_e( 'The selected payment method is not active in the MONEI dashboard. Or API key is incorrect', 'monei' ); ?>
 				<a href="https://dashboard.monei.com/?action=signIn"><?php esc_html_e( 'Go to your MONEI Dashboard to activate it', 'monei' ); ?></a>
-			</p>
+            </p>
 		</div>
 		<?php
 	}

--- a/woocommerce-gateway-monei.php
+++ b/woocommerce-gateway-monei.php
@@ -10,7 +10,7 @@
  * Plugin Name: MONEI Payments for WooCommerce
  * Plugin URI: https://wordpress.org/plugins/monei/
  * Description: Accept Card, Apple Pay, Google Pay, Bizum, PayPal and many more payment methods in your store.
- * Version: 6.3.2
+ * Version: 6.3.3
  * Author: MONEI
  * Author URI: https://www.monei.com/
  * Tested up to: 6.8


### PR DESCRIPTION
* Fix - Error copying old keys that hides the gateway. Also we will show the button to the API key settings even if the gateway is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an error that caused the payment gateway to be hidden when copying old API keys.
- **New Features**
  - Added a button in admin notices to quickly access the MONEI API key settings page.
- **Documentation**
  - Updated changelog and readme to reflect the latest version and bug fix.
  - Improved clarity in admin setting descriptions.
- **Chores**
  - Updated plugin version to 6.3.3 across all relevant files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->