### PR TITLE
Use central API key for PayPal method

### DIFF
--- a/src/Gateways/PaymentMethods/WCGatewayMoneiPaypal.php
+++ b/src/Gateways/PaymentMethods/WCGatewayMoneiPaypal.php
@@ -57,7 +57,7 @@ class WCGatewayMoneiPaypal extends WCMoneiPaymentGatewayHosted {
 		$this->title                = ( ! empty( $this->get_option( 'title' ) ) ) ? $this->get_option( 'title' ) : '';
 		$this->description          = ( ! empty( $this->get_option( 'description' ) ) ) ? $this->get_option( 'description' ) : '';
 		$this->status_after_payment = ( ! empty( $this->get_option( 'orderdo' ) ) ) ? $this->get_option( 'orderdo' ) : '';
-		$this->api_key              = ( ! empty( $this->get_option( 'apikey' ) ) ) ? $this->get_option( 'apikey' ) : '';
+		$this->api_key              = $this->getApiKey();
 		$this->shop_name            = get_bloginfo( 'name' );
 		$this->pre_auth             = ( ! empty( $this->get_option( 'pre-authorize' ) && 'yes' === $this->get_option( 'pre-authorize' ) ) ) ? true : false;
 		$this->logging              = ( ! empty( $this->get_option( 'debug' ) ) && 'yes' === $this->get_option( 'debug' ) ) ? true : false;


### PR DESCRIPTION
Fix the API key used for PayPal method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of API key retrieval for PayPal payment gateway integration. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->