### PR TITLE
fix: skip token creation in CC block checkout redirect mode

### DIFF
--- a/assets/js/components/monei-cc-component.js
+++ b/assets/js/components/monei-cc-component.js
@@ -113,6 +113,11 @@ export const MoneiCCContent = ( props ) => {
 	// Setup validation hook
 	useEffect( () => {
 		const unsubscribe = onCheckoutValidation( async () => {
+			// In redirect mode, no client-side validation needed
+			if ( isHostedWorkflow ) {
+				return true;
+			}
+
 			// Validate cardholder name
 			if ( ! cardholderName.validate() ) {
 				return {
@@ -150,6 +155,7 @@ export const MoneiCCContent = ( props ) => {
 		return unsubscribe;
 	}, [
 		onCheckoutValidation,
+		isHostedWorkflow,
 		cardholderName,
 		cardInput,
 		createPaymentToken,
@@ -160,6 +166,18 @@ export const MoneiCCContent = ( props ) => {
 	// Setup payment hook
 	useEffect( () => {
 		const unsubscribe = onPaymentSetup( async () => {
+			// In redirect mode, skip token creation — backend handles everything
+			if ( isHostedWorkflow ) {
+				return {
+					type: responseTypes.SUCCESS,
+					meta: {
+						paymentMethodData: {
+							monei_is_block_checkout: 'yes',
+						},
+					},
+				};
+			}
+
 			setIsProcessing( true );
 
 			try {
@@ -201,6 +219,7 @@ export const MoneiCCContent = ( props ) => {
 		return unsubscribe;
 	}, [
 		onPaymentSetup,
+		isHostedWorkflow,
 		cardholderName,
 		cardInput,
 		createPaymentToken,


### PR DESCRIPTION
## Summary
Fixes "MONEI token could not be generated" error when using credit card payment in block checkout with redirect mode enabled.

## Implementation
- Add `isHostedWorkflow` guard to `onCheckoutValidation` hook — returns `true` immediately in redirect mode
- Add `isHostedWorkflow` guard to `onPaymentSetup` hook — returns SUCCESS with `monei_is_block_checkout: 'yes'` in redirect mode
- Matches existing pattern in Bizum (`monei-block-checkout-bizum.js:198`) and PayPal (`monei-block-checkout-paypal.js:221`) block components

The CC block component rendered only the redirect description in hosted mode (line 277), but the `onCheckoutValidation` and `onPaymentSetup` event hooks were registered unconditionally. When the user clicked "Place Order", these hooks tried to create a token via `monei.createToken()` with no card input rendered, resulting in the error.

## Test plan
- [ ] Block checkout + CC redirect mode: click "Place Order" → should redirect to hosted payment page (no token error)
- [ ] Block checkout + CC component mode: enter card → click "Place Order" → token created, payment confirmed
- [ ] Block checkout + CC component mode with saved cards: select saved card → payment works
- [ ] Classic checkout + CC redirect mode: still works as before (unaffected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optimized payment validation and processing for hosted workflow mode to streamline the checkout experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->