### PR TITLE
test: pay with express PayPal on a store that does not ship

### DIFF
--- a/tests/playwright/specs/paypal-express.spec.js
+++ b/tests/playwright/specs/paypal-express.spec.js
@@ -12,7 +12,6 @@ const { expectOrderReceived } = require( '../utils/checkout' );
 const { readFixtures } = require( '../utils/fixtures' );
 const {
 	getOrderStatus,
-	getShippingMethodCount,
 	setExpressSettings,
 	getExpressSettings,
 } = require( '../utils/wp-cli' );
@@ -83,23 +82,13 @@ test.describe( 'Express checkout, PayPal', () => {
 	test( 'pays for a product with express PayPal', async ( { page } ) => {
 		test.setTimeout( PAYPAL_TIMEOUT );
 
-		// ⚠️ Needs a store that ships. monei.js only fetches the PayPal payer when
-		// `requestShipping` is true, so on a store with no shipping method the
-		// wallet returns a bare token — no email — and the order cannot be placed
-		// at all. Upstream as MONEI/monei-js#764. The seed removes every shipping
-		// method, so this skips there and runs on a store that has one.
-		test.skip(
-			getShippingMethodCount() === 0,
-			'Express PayPal returns no payer details on a store without shipping ' +
-				'methods — MONEI/monei-js#764.'
-		);
-
 		// ⚠️ The product page, not the cart, and the difference is not cosmetic.
 		// PayPal returns a partial address — name, email and country, no street or
-		// city. The classic product flow builds the order itself and accepts that,
-		// so it pays. The Cart and Checkout blocks go through the Store API, which
-		// rejects a partial shipping address outright. Same wallet, same payload,
-		// two outcomes; this test covers the one that can complete.
+		// city, because the shared sandbox account has none on file. The classic
+		// product flow builds the order itself and accepts that, so it pays. The
+		// Cart and Checkout blocks go through the Store API, which requires a full
+		// billing address and refuses. Same wallet, same payload, two outcomes;
+		// this test covers the one that can complete.
 		await page.goto( fixtures.productPath, {
 			waitUntil: 'domcontentloaded',
 		} );

--- a/tests/playwright/utils/paypal.js
+++ b/tests/playwright/utils/paypal.js
@@ -76,23 +76,49 @@ const expressPayPalButton = ( page ) =>
 /**
  * Clicks the wallet button and returns whatever PayPal opened.
  *
- * @param {import('@playwright/test').Page}    page   - Page under test
- * @param {import('@playwright/test').Locator} button - The wallet button
- * @return {Promise<Object>} A page (popup) or frame locator (overlay)
+ * ⚠️ Racing `waitForEvent('popup')` against the click is not enough, and the
+ * failure it causes points at the wrong thing. The popup sometimes arrives after
+ * the race gives up, and the overlay fallback then matches an iframe zoid has
+ * appended as `about:blank` but not yet navigated — so the wait for the login
+ * field times out on a surface that was never PayPal. Poll both instead, and
+ * only accept a frame that has actually reached paypal.com.
+ *
+ * @param {import('@playwright/test').Page}    page      - Page under test
+ * @param {import('@playwright/test').Locator} button    - The wallet button
+ * @param {number}                             [timeout] - How long to keep looking
+ * @return {Promise<Object>} The popup page, or the overlay frame
  */
-const openPayPal = async ( page, button ) => {
-	const [ popup ] = await Promise.all( [
-		page.waitForEvent( 'popup', { timeout: 20000 } ).catch( () => null ),
-		button.click(),
-	] );
+const openPayPal = async ( page, button, timeout = 60000 ) => {
+	const isLogin = ( url ) =>
+		url.includes( 'paypal.com' ) && ! url.includes( 'smart/buttons' );
 
-	return (
-		popup ??
-		page
-			.frameLocator(
-				'iframe[src*="paypal.com"]:not([src*="smart/buttons"])'
-			)
-			.first()
+	await button.click();
+
+	const deadline = Date.now() + timeout;
+
+	while ( Date.now() < deadline ) {
+		const popup = page
+			.context()
+			.pages()
+			.find( ( other ) => other !== page && isLogin( other.url() ) );
+
+		if ( popup ) {
+			return popup;
+		}
+
+		const overlay = page
+			.frames()
+			.find( ( frame ) => isLogin( frame.url() ) );
+
+		if ( overlay ) {
+			return overlay;
+		}
+
+		await page.waitForTimeout( 500 );
+	}
+
+	throw new Error(
+		'PayPal did not open a login surface within ' + timeout + 'ms'
 	);
 };
 

--- a/tests/playwright/utils/wp-cli.js
+++ b/tests/playwright/utils/wp-cli.js
@@ -140,19 +140,6 @@ const ensureCoupon = ( code, percent ) => {
 };
 
 /**
- * How many shipping methods the store offers.
- *
- * Decides whether express asks the wallet for a shipping address, which in turn
- * decides whether PayPal returns any payer details at all — see MONEI/monei-js#764.
- * @return {number} Enabled shipping method count
- */
-const getShippingMethodCount = () =>
-	parseInt(
-		wpCli( [ 'eval', 'echo wc_get_shipping_method_count( true );' ] ),
-		10
-	) || 0;
-
-/**
  * Read the WooCommerce status of an order.
  *
  * The thank you page only says the browser landed somewhere; the order status is
@@ -294,5 +281,4 @@ module.exports = {
 	setCheckoutPageId,
 	ensureCoupon,
 	getOrderStatus,
-	getShippingMethodCount,
 };


### PR DESCRIPTION
monei.js now returns the PayPal payer when `requestShipping` is false ([monei-js#764](https://github.com/MONEI/monei-js/issues/764), closed), so the product-page spec no longer has to skip on a store with no shipping method.

Verified against a store with zero shipping methods — the exact condition that used to fail. Order `#1787769238731`, status `processing`, €18.00, and the wallet payload now carries `billing[name]` and `billing[email]`.

Suite: **14 passed, 0 skipped, 0 failed** (was 13 + 1 skipped).

## Changes

- Drop the skip and the `getShippingMethodCount` helper that existed only to feed it.
- Fix `openPayPal`. It raced a 20s popup event against the click and fell back to an overlay frame locator. A popup arriving after the race then left the fallback waiting for a login field inside an iframe zoid had appended as `about:blank` and not yet navigated — which reads as PayPal being broken rather than as a harness bug. It polls both surfaces now and only accepts a frame that has actually reached paypal.com.

## Not fixed, because it is not ours

PayPal returns name, email and country but no street address — the shared sandbox account has none saved. Confirmed it is the account and not `requestShipping`: with a shipping method enabled, so `requestShipping` true, PayPal returned the same partial address. So the Cart and Checkout blocks still cannot place an express PayPal order with this account, because the Store API requires a full billing address. The spec's comment says so, and the second test still guards that the shopper is told why rather than left on a silent cart.