### PR TITLE
fix: pre-authorize wallet payments and let the capture actually stick

### DIFF
--- a/class-woocommerce-gateway-monei.php
+++ b/class-woocommerce-gateway-monei.php
@@ -145,8 +145,15 @@ if ( ! class_exists( 'Woocommerce_Gateway_Monei' ) ) :
 			include_once 'includes/class-wc-monei-logger.php';
 			include_once 'includes/class-wc-monei-payment-method-display.php';
 
+			// Capture listens on order status transitions, which are not an admin
+			// event. A shipping plugin, an ERP sync, WP-CLI, cron or the REST API
+			// moves an order to Processing exactly like a human does, and while
+			// this only loaded for `is_admin()` every one of those took the
+			// authorization no further — the money stayed held until it expired,
+			// with the order reading as paid and no note saying otherwise.
+			include_once 'includes/class-wc-monei-pre-auth.php';
+
 			if ( $this->is_request( 'admin' ) ) {
-				include_once 'includes/class-wc-monei-pre-auth.php';
 				add_filter(
 					'woocommerce_get_settings_pages',
 					function ( $settings ) use ( $container ) {

--- a/includes/class-wc-monei-pre-auth.php
+++ b/includes/class-wc-monei-pre-auth.php
@@ -49,12 +49,15 @@ class WC_Monei_Pre_Auth {
 			$this->moneiPaymentServices->set_order( $order );
 			$result = $this->moneiPaymentServices->capture_payment( $payment_id, monei_price_format( $order->get_total() ) );
 			// Deleting pre-auth metadata, once the order is captured.
-			// ⚠️ `delete_meta_data()` only changes the object in memory. Without the
-			// save the marker survives the capture, so a captured order still reads
-			// as holding uncaptured money and a later cancellation would try to
-			// release an authorization that is already gone.
+			// ⚠️ `delete_meta_data()` only changes the object in memory, so the
+			// deletion has to be persisted or the marker survives the capture and a
+			// later cancellation tries to release an authorization already gone.
+			// ⚠️ `save_meta_data()` and NOT `save()`: this runs inside a status
+			// transition, where the order object still carries the status it is
+			// moving away from. A full save writes that stale status back and puts
+			// the order straight back on hold — captured, but reading as unpaid.
 			$order->delete_meta_data( '_payment_not_captured_monei' );
-			$order->save();
+			$order->save_meta_data();
 
 			WC_Monei_Logger::logDebug( 'Capture Payment OK.' );
 			WC_Monei_Logger::logDebug( $result );
@@ -83,7 +86,7 @@ class WC_Monei_Pre_Auth {
 			// A released authorization holds nothing either, so the marker goes the
 			// same way it does after a capture.
 			$order->delete_meta_data( '_payment_not_captured_monei' );
-			$order->save();
+			$order->save_meta_data();
 
 			WC_Monei_Logger::logDebug( 'Cancel Payment Payment OK.' );
 			WC_Monei_Logger::logDebug( $result );

--- a/includes/class-wc-monei-pre-auth.php
+++ b/includes/class-wc-monei-pre-auth.php
@@ -49,7 +49,12 @@ class WC_Monei_Pre_Auth {
 			$this->moneiPaymentServices->set_order( $order );
 			$result = $this->moneiPaymentServices->capture_payment( $payment_id, monei_price_format( $order->get_total() ) );
 			// Deleting pre-auth metadata, once the order is captured.
+			// ⚠️ `delete_meta_data()` only changes the object in memory. Without the
+			// save the marker survives the capture, so a captured order still reads
+			// as holding uncaptured money and a later cancellation would try to
+			// release an authorization that is already gone.
 			$order->delete_meta_data( '_payment_not_captured_monei' );
+			$order->save();
 
 			WC_Monei_Logger::logDebug( 'Capture Payment OK.' );
 			WC_Monei_Logger::logDebug( $result );
@@ -75,6 +80,11 @@ class WC_Monei_Pre_Auth {
 		try {
 			$this->moneiPaymentServices->set_order( $order );
 			$result = $this->moneiPaymentServices->cancel_payment( $payment_id );
+			// A released authorization holds nothing either, so the marker goes the
+			// same way it does after a capture.
+			$order->delete_meta_data( '_payment_not_captured_monei' );
+			$order->save();
+
 			WC_Monei_Logger::logDebug( 'Cancel Payment Payment OK.' );
 			WC_Monei_Logger::logDebug( $result );
 			$order->add_order_note( '<strong>Cancel Payment approved</strong>: Status: ' . $result->getStatus() . ' ' . $result->getStatusMessage() . ' ' . $result->getStatusCode() );

--- a/src/Gateways/PaymentMethods/WCGatewayMoneiAppleGoogle.php
+++ b/src/Gateways/PaymentMethods/WCGatewayMoneiAppleGoogle.php
@@ -84,9 +84,13 @@ class WCGatewayMoneiAppleGoogle extends WCMoneiPaymentGatewayComponent {
 		$this->shop_name     = get_bloginfo( 'name' );
 		$this->redirect_flow = false;
 		$this->tokenization  = false;
-		$this->pre_auth      = false;
-		$this->logging       = ( ! empty( get_option( 'monei_debug' ) ) && 'yes' === get_option( 'monei_debug' ) ) ? true : false;
-		$this->supports      = array(
+		// Apple Pay and Google Pay are card payments, so MONEI authorizes them like
+		// any other card. Backward compatible: try local setting first, then global.
+		$local_preauth  = $this->get_option( 'pre-authorize' );
+		$global_preauth = get_option( 'monei_pre_authorize', 'no' );
+		$this->pre_auth = ( ! empty( $local_preauth ) && 'yes' === $local_preauth ) || ( empty( $local_preauth ) && 'yes' === $global_preauth );
+		$this->logging  = ( ! empty( get_option( 'monei_debug' ) ) && 'yes' === get_option( 'monei_debug' ) ) ? true : false;
+		$this->supports = array(
 			'products',
 			'refunds',
 		);

--- a/tests/playwright/specs/express-payment.spec.js
+++ b/tests/playwright/specs/express-payment.spec.js
@@ -9,8 +9,12 @@ const {
 } = require( '../utils/checkout' );
 const {
 	getExpressSettings,
+	getOption,
+	getOrderMeta,
 	getOrderStatus,
 	setExpressSettings,
+	setOption,
+	setOrderStatus,
 } = require( '../utils/wp-cli' );
 
 /**
@@ -129,6 +133,79 @@ const mountCardInput = async ( page, sessionId, amount ) => {
 	);
 };
 
+/**
+ * A whole express order, from the product page to the store's redirect.
+ *
+ * Stops at the redirect rather than following it, because what the order should
+ * become next is the thing each test is about.
+ * @param {import('@playwright/test').Page} page - Page under test
+ * @return {Promise<Object>} The `create_order` response body
+ */
+const placeExpressOrder = async ( page ) => {
+	await page.goto( PRODUCT_PATH, { waitUntil: 'domcontentloaded' } );
+
+	// Also the assertion that the express assets reached the product page
+	// with a usable account id, which is what the wallet needs to render.
+	await expect
+		.poll( () =>
+			page.evaluate(
+				() => window.wc_monei_express_params?.accountId || ''
+			)
+		)
+		.not.toBe( '' );
+
+	const bootstrap = await expressPost( page, 'bootstrap' );
+	expect( bootstrap.body.result ).toBe( 'success' );
+
+	const security = bootstrap.body.nonce;
+	const sessionId = bootstrap.body.sessionId;
+
+	const cart = await expressPost( page, 'add_to_cart', {
+		security,
+		product_id: PRODUCT_ID,
+		quantity: 1,
+	} );
+	expect( cart.body.result ).toBe( 'success' );
+
+	const amount = cart.body.amount;
+	expect( amount ).toBeGreaterThan( 0 );
+
+	await mountCardInput( page, sessionId, amount );
+	await fillCard( page, 'single', CARDS.visaFrictionless );
+
+	const submitted = await page.evaluate( () =>
+		window.__moneiE2eCardInput.submit()
+	);
+	expect(
+		submitted.error,
+		'the card component returned a token'
+	).toBeFalsy();
+	expect( submitted.token ).toBeTruthy();
+
+	const created = await expressPost( page, 'create_order', {
+		security,
+		session_id: sessionId,
+		location: 'product',
+		payment_method: 'card',
+		monei_payment_request_token: submitted.token,
+		// The cart carries no shippable line while the store has no shipping
+		// method, so the wallet would report no option either.
+		shipping_option: '',
+		final_amount: String( amount ),
+		...BILLING_FIELDS,
+		...SHIPPING_FIELDS,
+	} );
+
+	expect(
+		created.body.data?.code,
+		`express order refused: ${ created.body.data?.message || '' }`
+	).toBeUndefined();
+	expect( created.body.result ).toBe( 'success' );
+	expect( created.body.orderId ).toBeGreaterThan( 0 );
+
+	return created.body;
+};
+
 let previousSettings;
 
 test.describe( 'Express checkout payment', () => {
@@ -149,78 +226,76 @@ test.describe( 'Express checkout payment', () => {
 	test( 'pays a product page express order with a real token', async ( {
 		page,
 	} ) => {
-		await page.goto( PRODUCT_PATH, { waitUntil: 'domcontentloaded' } );
-
-		// Also the assertion that the express assets reached the product page
-		// with a usable account id, which is what the wallet needs to render.
-		await expect
-			.poll( () =>
-				page.evaluate(
-					() => window.wc_monei_express_params?.accountId || ''
-				)
-			)
-			.not.toBe( '' );
-
-		const bootstrap = await expressPost( page, 'bootstrap' );
-		expect( bootstrap.body.result ).toBe( 'success' );
-
-		const security = bootstrap.body.nonce;
-		const sessionId = bootstrap.body.sessionId;
-
-		const cart = await expressPost( page, 'add_to_cart', {
-			security,
-			product_id: PRODUCT_ID,
-			quantity: 1,
-		} );
-		expect( cart.body.result ).toBe( 'success' );
-
-		const amount = cart.body.amount;
-		expect( amount ).toBeGreaterThan( 0 );
-
-		await mountCardInput( page, sessionId, amount );
-		await fillCard( page, 'single', CARDS.visaFrictionless );
-
-		const submitted = await page.evaluate( () =>
-			window.__moneiE2eCardInput.submit()
-		);
-		expect(
-			submitted.error,
-			'the card component returned a token'
-		).toBeFalsy();
-		expect( submitted.token ).toBeTruthy();
-
-		const created = await expressPost( page, 'create_order', {
-			security,
-			session_id: sessionId,
-			location: 'product',
-			payment_method: 'card',
-			monei_payment_request_token: submitted.token,
-			// The cart carries no shippable line while the store has no shipping
-			// method, so the wallet would report no option either.
-			shipping_option: '',
-			final_amount: String( amount ),
-			...BILLING_FIELDS,
-			...SHIPPING_FIELDS,
-		} );
-
-		expect(
-			created.body.data?.code,
-			`express order refused: ${ created.body.data?.message || '' }`
-		).toBeUndefined();
-		expect( created.body.result ).toBe( 'success' );
-		expect( created.body.orderId ).toBeGreaterThan( 0 );
+		const created = await placeExpressOrder( page );
 
 		// What the express client does with the response, and the only part of
 		// the flow after the sheet that is still a browser journey: the 3DS
 		// redirect and the return to the store.
-		await page.goto( created.body.redirect );
+		await page.goto( created.redirect );
 		await completeThreeDsChallengeIfShown( page );
 
 		const orderId = await expectOrderReceived( page );
-		expect( Number( orderId ) ).toBe( created.body.orderId );
+		expect( Number( orderId ) ).toBe( created.orderId );
 
 		// The assertion that separates a real payment from a created order: only
 		// money that actually moved takes an order out of `pending`.
 		expect( getOrderStatus( orderId ) ).toBe( 'processing' );
+	} );
+
+	test.describe( 'with Payment Action set to Authorization', () => {
+		let previousAction;
+
+		test.beforeAll( () => {
+			previousAction = getOption( 'monei_pre_authorize' );
+			setOption( 'monei_pre_authorize', 'yes' );
+		} );
+
+		test.afterAll( () => {
+			setOption( 'monei_pre_authorize', previousAction || 'no' );
+		} );
+
+		// 🚨 Regression guard. The Apple Pay / Google Pay gateway used to set
+		// `pre_auth = false` unconditionally, next to the `redirect_flow` and
+		// `tokenization` flags it genuinely does not support. Those two are real
+		// limitations; this one was not — a wallet payment is a card payment, and
+		// MONEI authorizes it like any other. A merchant who chose Authorization
+		// got an immediate charge from these two methods and no warning that the
+		// setting did not apply, while the settings screen listed them as
+		// supported.
+		test( 'holds the money instead of taking it, then captures', async ( {
+			page,
+		} ) => {
+			const created = await placeExpressOrder( page );
+
+			await page.goto( created.redirect );
+			await completeThreeDsChallengeIfShown( page );
+
+			const orderId = await expectOrderReceived( page );
+
+			expect(
+				getOrderStatus( orderId ),
+				'an authorized express order waits on-hold rather than being paid'
+			).toBe( 'on-hold' );
+			expect(
+				getOrderMeta( orderId, '_payment_not_captured_monei' ),
+				'the order is marked as holding uncaptured money'
+			).toBe( '1' );
+
+			// Capture is not a button — it is what moving the order to Processing
+			// does. This is the half a merchant actually performs.
+			setOrderStatus( orderId, 'processing' );
+
+			await expect
+				.poll(
+					() =>
+						getOrderMeta( orderId, '_payment_not_captured_monei' ),
+					{
+						message:
+							'the capture cleared the uncaptured marker on the order',
+					}
+				)
+				.toBe( '' );
+			expect( getOrderStatus( orderId ) ).toBe( 'processing' );
+		} );
 	} );
 } );

--- a/tests/playwright/utils/wp-cli.js
+++ b/tests/playwright/utils/wp-cli.js
@@ -140,6 +140,58 @@ const ensureCoupon = ( code, percent ) => {
 };
 
 /**
+ * Read a plain WordPress option, or an empty string when it is not set.
+ * @param {string} name - Option name
+ * @return {string} Option value
+ */
+const getOption = ( name ) => {
+	try {
+		return wpCli( [ 'option', 'get', name ] );
+	} catch ( error ) {
+		return '';
+	}
+};
+
+/**
+ * Write a plain WordPress option.
+ * @param {string} name  - Option name
+ * @param {string} value - Value to store
+ */
+const setOption = ( name, value ) =>
+	wpCli( [ 'option', 'update', name, value ] );
+
+/**
+ * Move an order to a WooCommerce status, the way an admin would.
+ * @param {string|number} orderId - Order id
+ * @param {string}        status  - Target status, without the `wc-` prefix
+ */
+const setOrderStatus = ( orderId, status ) =>
+	wpCli( [
+		'wc',
+		'shop_order',
+		'update',
+		String( orderId ),
+		'--user=1',
+		`--status=${ status }`,
+	] );
+
+/**
+ * Read one meta value from an order.
+ *
+ * ⚠️ Goes through `wc_get_order()` rather than the posts meta table: with HPOS
+ * the order lives in its own table, and `wp post meta get` would read nothing.
+ * @param {string|number} orderId - Order id
+ * @param {string}        key     - Meta key
+ * @return {string} Meta value, empty when absent
+ */
+const getOrderMeta = ( orderId, key ) =>
+	wpCli( [
+		'eval',
+		`$o = wc_get_order( ${ Number( orderId ) } );` +
+			`echo $o ? (string) $o->get_meta( '${ key }', true ) : '';`,
+	] );
+
+/**
  * Read the WooCommerce status of an order.
  *
  * The thank you page only says the browser landed somewhere; the order status is
@@ -281,4 +333,8 @@ module.exports = {
 	setCheckoutPageId,
 	ensureCoupon,
 	getOrderStatus,
+	getOption,
+	setOption,
+	setOrderStatus,
+	getOrderMeta,
 };


### PR DESCRIPTION
Started as "Apple Pay / Google Pay ignore Payment Action". Fixing that exposed two more defects on the same path, each hidden by the one before it.

## 1. Apple Pay and Google Pay never pre-authorized

`WCGatewayMoneiAppleGoogle` set `pre_auth = false` unconditionally, next to the `redirect_flow` and `tokenization` flags it genuinely does not support. Those two are real limitations. This one was not — a wallet payment is a card payment and MONEI authorizes it like any other.

A merchant who chose **Authorization** got an immediate charge from these two methods, while the settings screen listed them as supported.

Now reads the setting exactly as the Card and PayPal gateways do. Express goes through `process_payment()`, so classic and express are both covered by the one change.

## 2. Capture only ran inside wp-admin

`class-wc-monei-pre-auth.php` registers the order-status hooks that capture and cancel, and it was included under `is_request( 'admin' )`.

Capture is not an admin event. A shipping plugin, an ERP sync, WP-CLI, cron or the REST API moves an order to Processing exactly like a human does — and every one of those took the authorization no further. The money stayed held until it expired after 7 days, the order read as paid, and no note said otherwise.

This is the more serious of the three: it affects Card and PayPal too, on any store that automates fulfilment.

## 3. Capture never cleared its own marker

```php
$order->delete_meta_data( '_payment_not_captured_monei' );
// no save()
```

`delete_meta_data()` only changes the object in memory. Order notes persisted because `add_order_note()` writes straight to its own table, which is what made this look like it worked. A captured order kept reporting that it held uncaptured money, and a later cancellation would try to release an authorization that was already gone. The cancel path never cleared the marker at all.

## Verified

New spec drives a real express wallet order with Payment Action set to Authorization:

- the order waits `on-hold` with `_payment_not_captured_monei` set, rather than being charged
- moving it to Processing captures for real — MONEI returns `SUCCEEDED`, the order note says `Capture approved`, and the marker is gone

Each fix was confirmed by watching the previous assertion fail for the right reason first: without #2 the order reached Processing with no capture note at all; without #3 the capture succeeded and the marker survived.

The express flow itself was extracted into `placeExpressOrder()` so both tests share it rather than duplicating ~70 lines.

- `pnpm test:e2e` — 13 passed, 0 failed
- `pnpm lint:php` — PHPCS clean, PHPStan no errors

The one skip and one flaky in that run are both `paypal-express.spec.js`, fixed separately in #117.

## Docs

[MONEI/docs#483](https://github.com/MONEI/docs/pull/483) currently documents pre-authorization as Card and PayPal only, which is true of 7.2.3. It needs updating to include Apple Pay and Google Pay when this ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-authorization data is now consistently cleared and saved after successful payment capture or cancellation.
  * Apple Pay and Google Pay now correctly respect their configured pre-authorization setting, with a global fallback.
  * Authorization payments remain on hold until captured, then transition correctly to processing.

* **Tests**
  * Expanded automated coverage for express payments, authorization flows, order statuses, and payment metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->