### PR TITLE
feat: show the card fields as separate fields by default

### DIFF
--- a/includes/admin/monei-cc-settings.php
+++ b/includes/admin/monei-cc-settings.php
@@ -78,7 +78,7 @@ return apply_filters(
 			'title'       => __( 'Card Field Layout', 'monei' ),
 			'type'        => 'select',
 			'description' => __( 'Show the card fields on a single line, or as separate card number, expiry and CVC fields.', 'monei' ),
-			'default'     => 'single',
+			'default'     => 'split',
 			'desc_tip'    => true,
 			'options'     => array(
 				'single' => __( 'Single line', 'monei' ),

--- a/src/Gateways/Blocks/MoneiCCBlocksSupport.php
+++ b/src/Gateways/Blocks/MoneiCCBlocksSupport.php
@@ -143,7 +143,7 @@ final class MoneiCCBlocksSupport extends AbstractPaymentMethodType {
 			'total'            => $total,
 			'language'         => locale_iso_639_1_code(),
 			'cardInputStyle'   => json_decode( $card_input_style ),
-			'cardFieldLayout'  => $this->get_setting( 'card_field_layout', 'single' ),
+			'cardFieldLayout'  => $this->get_setting( 'card_field_layout', 'split' ),
 			'cardBrands'       => $this->cardBrandHelper->getCardBrandsConfig(),
 		);
 

--- a/src/Gateways/PaymentMethods/WCGatewayMoneiCC.php
+++ b/src/Gateways/PaymentMethods/WCGatewayMoneiCC.php
@@ -417,7 +417,7 @@ class WCGatewayMoneiCC extends WCMoneiPaymentGatewayComponent {
 			</div>
 			<!-- Card Input Container -->
 			<div id="payment-form" class="monei-input-container wc-block-components-text-input">
-				<?php if ( 'split' === $this->get_option( 'card_field_layout', 'single' ) ) : ?>
+				<?php if ( 'split' === $this->get_option( 'card_field_layout', 'split' ) ) : ?>
 					<!-- Split Card Field Containers, in tab order -->
 					<div class="monei-card-group">
 						<div id="monei-card-number" class="monei-card-group-field monei-card-number"></div>
@@ -503,7 +503,7 @@ class WCGatewayMoneiCC extends WCMoneiPaymentGatewayComponent {
 				'currency'        => get_woocommerce_currency(),
 				'appleLogo'       => WC_Monei()->image_url( 'apple-logo.svg' ),
 				'cardInputStyle'  => json_decode( $card_input_style ),
-				'cardFieldLayout' => $this->get_option( 'card_field_layout', 'single' ),
+				'cardFieldLayout' => $this->get_option( 'card_field_layout', 'split' ),
 				'cardBrands'      => $this->cardBrandHelper->getCardBrandsConfig(),
 				'nameErrorString' => esc_html__( 'Please enter a valid name. Special characters are not allowed.', 'monei' ),
 			)

--- a/tests/playwright/utils/wp-cli.js
+++ b/tests/playwright/utils/wp-cli.js
@@ -54,17 +54,18 @@ const wpCli = ( args ) => {
 
 /**
  * Set the MONEI credit card field layout.
+ *
+ * ⚠️ Merged rather than patched, for the same reason `mergeSettings` exists:
+ * `option patch` refuses a key the option does not carry yet, and a store whose
+ * merchant never saved the card settings has no `card_field_layout` at all. That
+ * is the normal state of a fresh install, not an edge case — and more common now
+ * that the layout has a default worth keeping.
  * @param {'single'|'split'} layout - Layout to activate
  */
 const setCardFieldLayout = ( layout ) =>
-	wpCli( [
-		'option',
-		'patch',
-		'update',
-		'woocommerce_monei_settings',
-		'card_field_layout',
-		layout,
-	] );
+	mergeSettings( 'woocommerce_monei_settings', {
+		card_field_layout: layout,
+	} );
 
 /**
  * Read the current MONEI credit card field layout.
@@ -79,7 +80,9 @@ const getCardFieldLayout = () => {
 			'--format=json',
 		] )
 	);
-	return settings.card_field_layout || 'single';
+	// Mirrors the gateway's own default for an unsaved setting. A stale value here
+	// makes a spec restore a layout the store never had.
+	return settings.card_field_layout || 'split';
 };
 
 /**


### PR DESCRIPTION
CardGroup becomes the default card layout, on the merchant's instruction to flip it for every store rather than new installs only.

## Blast radius

A store that **never saved** the MONEI Cards settings has no stored `card_field_layout`, so it inherits the default and its checkout moves from one line to three fields on the next auto-update, with no merchant action. A store that **did** choose single line keeps it — that choice is stored explicitly.

This was raised before implementing and the decision was to flip for everyone. Recording it here so it is not a surprise in support.

## Changes

Four defaults, `single` → `split`:

- `includes/admin/monei-cc-settings.php` — the form field default
- `src/Gateways/PaymentMethods/WCGatewayMoneiCC.php` — classic checkout, both call sites
- `src/Gateways/Blocks/MoneiCCBlocksSupport.php` — blocks checkout

Plus one test-helper fix that is not cosmetic: `setCardFieldLayout` used `wp option patch update`, which refuses a key the option does not carry yet. A fresh store whose merchant never opened that settings screen has no `card_field_layout`, so all three card specs failed against it. `mergeSettings` already existed for exactly this reason, with a comment explaining it — this helper had never been switched over. Split as the default makes it more likely to bite, since there is now less reason to ever save that screen.

`getCardFieldLayout`'s fallback moved to `split` too, so it mirrors the gateway rather than restoring a layout the store never had.

## Verified

Not just the constant — the case that actually matters:

1. Deleted the stored `card_field_layout` to simulate a store that never saved the settings.
2. Gateway resolves `split`; form field default reads `split`.
3. Loaded the real checkout: one `.monei-card-fieldset`, zero `.monei-card-input`.
4. Full suite re-run **with the key still absent**, so the helper fix is proven from the broken state rather than after tidying it away.

Local: PHPStan + PHPCS clean. E2E 15/15 — the three card specs pass from the absent-key state; the two PayPal specs failed one run on `PayPal did not open a login surface` and passed 2/2 on an immediate re-run, which is the sandbox, not this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Separate card fields are now selected by default during checkout.
  * The split card layout is consistently applied across standard and block-based checkout experiences when no preference is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->